### PR TITLE
Idea filtering #15

### DIFF
--- a/app/assets/javascripts/ideas-crud.js
+++ b/app/assets/javascripts/ideas-crud.js
@@ -28,10 +28,10 @@ function createIdea() {
 function renderIdea(idea) {
   $('#ideas-all').prepend(
     '<tr class="idea" data-id="' + idea.id + '">'
-    + '<td>'
+    + '<td class="searchable">'
     + idea.title
     + '</td>'
-    + '<td>'
+    + '<td class="searchable">'
     + idea.body
     + '</td>'
     + '<td class="idea-quality">'

--- a/app/assets/javascripts/ideas-search.js
+++ b/app/assets/javascripts/ideas-search.js
@@ -1,0 +1,13 @@
+$(document).ready(function() {
+  searchIdeas();
+});
+
+function searchIdeas() {
+  $('#idea-search').on('input', function() {
+    var $ideas = $('.idea');
+    var $search = $(this).val();
+
+    $('.searchable:not(:contains(' + $search + '))').parent().hide();
+    $('.searchable:contains(' + $search + ')').parent().show();
+  });
+};

--- a/app/views/ideas/index.html.erb
+++ b/app/views/ideas/index.html.erb
@@ -1,3 +1,5 @@
+<%= label_tag :search %>
+<%= text_field_tag :search, nil, id: "idea-search" %>
 <%= label_tag :title %>
 <%= text_field_tag :title, nil, id: "idea-title" %>
 <%= label_tag :body %>
@@ -19,8 +21,10 @@
   <tbody id="ideas-all">
   <% @ideas.each do |idea| %>
     <tr class="idea" data-id="<%= idea.id %>">
-      <td><%= idea.title %></td>
-      <td><%= truncate(idea.body, length: 100, separator: " ") %></td>
+      <td class="searchable"><%= idea.title %></td>
+      <td class="searchable">
+        <%= truncate(idea.body, length: 100, separator: " ") %>
+      </td>
       <td class="idea-quality"><%= idea.quality %></td>
       <td><%= link_to "Like", "#", class: "idea-like" %></td>
       <td><%= link_to "Dislike", "#", class: "idea-dislike" %></td>

--- a/spec/features/idea_filtering_spec.rb
+++ b/spec/features/idea_filtering_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.feature "Idea filtering", type: :feature do
+  before do
+    visit root_path
+
+    fill_in("title", with: "Title one")
+    fill_in("body", with: "A bird in the hand is worth two in the bush.")
+    click_button("Save")
+    fill_in("title", with: "Title two")
+    fill_in("body", with: "To be, or not to be; that is the question.")
+    click_button("Save")
+    fill_in("title", with: "Another one")
+    fill_in("body", with: "bites the dust")
+    click_button("Save")
+  end
+
+  scenario "User enters filter term in search box that matches two titles",
+           js: true do
+    fill_in("search", with: "one")
+    wait_for_ajax
+
+    expect(page).to_not have_content("Title two")
+    expect(page).to_not have_content("To be, or not to be; that is the question.")
+    expect(page).to have_content("Title one")
+    expect(page).to have_content("A bird in the hand is worth two in the bush.")
+    expect(page).to have_content("Another one")
+    expect(page).to have_content("bites the dust")
+  end
+end

--- a/spec/features/idea_search_spec.rb
+++ b/spec/features/idea_search_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Idea filtering", type: :feature do
+RSpec.feature "Idea searching", type: :feature do
   before do
     visit root_path
 
@@ -15,7 +15,7 @@ RSpec.feature "Idea filtering", type: :feature do
     click_button("Save")
   end
 
-  scenario "User enters filter term in search box that matches two titles",
+  xscenario "User enters search term that matches two titles",
            js: true do
     fill_in("search", with: "one")
     wait_for_ajax


### PR DESCRIPTION
- At the top of the idea list, include a text field labeled "Search"
- As a user types in the search box, the list of ideas should filter in real time to only display ideas whose title or body include the user's text (the page should not reload)
- Clearing the search box should restore all the ideas to the list

Closes #15 
